### PR TITLE
improve bond detection between hydrogens, sulfurs, atoms with alt codes and prevent bonds between different models

### DIFF
--- a/code/state.c
+++ b/code/state.c
@@ -300,11 +300,7 @@ set_bonddistance (void)
 {
   assert (dstack_size == 1);
 
-  if (dstack[0] <= 0.0) {
-    yyerror ("invalid bonddistance value");
-  } else {
-    current_state->bonddistance = dstack[0];
-  }
+  current_state->bonddistance = dstack[0];
   clear_dstack();
 }
 

--- a/doc/state.html
+++ b/doc/state.html
@@ -243,6 +243,12 @@ distance will have <a href="atom_commands.html#bonds">bonds</a> or
 <a href="atom_commands.html#ball-and-stick">sticks</a>
 drawn between them, otherwise not, when selected in the respective
 command. The unit is &Aring;ngstr&ouml;m. 
+
+<br>
+<br><b>New (Oct 2015):</b> A value of 0.0 will detect bonds based
+on atom radii overlap. It will also prevent bonding between different
+alt locations and different models.
+
 <p>
 <b>Default:</b> 1.9
 <br>


### PR DESCRIPTION
This patch doesn't change the default behavior of MolScript, but it activates some fine tuned bonding rules if the bonddistance parameter is set to 0.0.

* prevent bonds between different alt locations
* prevent bonds between different models
* do radii overlap dependent bond detection, with special cutoffs for hydrogens and sulfurs

The cutoffs are hard coded and borrowed from PyMOL.

I also suggest to make bonddistance=0.0 the default with molauto.